### PR TITLE
docs: Add LibHunt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@
 
   * [GitHub Trending](https://github.com/trending)
   * [Awesome Lists](https://awesome.re/)
+  * [LibHunt](https://ideabin.xyz/) – tracking mentions of GitHub repositories on Reddit etc.
 
 * **AI/ML Tools**
 


### PR DESCRIPTION
Obvious Product Hunt alternative for open source projects 😄

I’m in no way affiliated with LibHunt.